### PR TITLE
Fix typo in refresh method docs

### DIFF
--- a/Software/src/APP.kt
+++ b/Software/src/APP.kt
@@ -190,7 +190,7 @@ object APP {
     }
 
     /**
-     * Limpa a tela LCD, e em seguinda executa o lambda [write1] para escrever na tela, mesma coisa para o [write2]
+     * Limpa a tela LCD, e em seguida executa o lambda [write1] para escrever na tela, mesma coisa para o [write2]
      * ambos em linhas diferentes
      * @param write1 uma função de extensão do TUI
      * @param write2 uma função de extensão do TUIa

--- a/Software/src/APPbeta.kt
+++ b/Software/src/APPbeta.kt
@@ -200,7 +200,7 @@ object APPbeta {
     }
 
     /**
-     * Limpa a tela LCD, e em seguinda executa o lambda [write1] para escrever na tela, mesma coisa para o [write2]
+     * Limpa a tela LCD, e em seguida executa o lambda [write1] para escrever na tela, mesma coisa para o [write2]
      * ambos em linhas diferentes
      * @param write1 uma função de extensão do TUI
      * @param write2 uma função de extensão do TUIa

--- a/Software/src/TUI.kt
+++ b/Software/src/TUI.kt
@@ -300,7 +300,7 @@ object TUI {
     fun isValid(key: Char): Boolean = key != NONE
 
     /**
-     * Limpa a tela LCD, e em seguinda executa o lambda [write1] para escrever na tela, mesma coisa para o [write2]
+     * Limpa a tela LCD, e em seguida executa o lambda [write1] para escrever na tela, mesma coisa para o [write2]
      * ambos em linhas diferentes
      * @param write1 uma função de extensão do TUI
      * @param write2 uma função de extensão do TUIa


### PR DESCRIPTION
## Summary
- correct `em seguinda` to `em seguida` in refresh comments

## Testing
- `kotlinc Software/src/*.kt -include-runtime -d test.jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848494a49208332acbc5f97ff83cc3c