### PR TITLE
Fix Portuguese comment in TUI.kt

### DIFF
--- a/Software/src/TUI.kt
+++ b/Software/src/TUI.kt
@@ -195,7 +195,7 @@ object TUI {
     }
 
     /**
-     * Quria uma animação de screen de load. Para quando a condição for verdadeira
+     * Cria uma animação de loading screen. Para quando a condição for verdadeira
      * @param time
      * @param condition
      */


### PR DESCRIPTION
## Summary
- fix typo in `loadingScreen` comment

## Testing
- `kotlinc -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684849216b988332b43bb80d3f0151b7