### PR TITLE
Update M input index

### DIFF
--- a/Software/src/M.kt
+++ b/Software/src/M.kt
@@ -8,7 +8,7 @@ object M {
 
     val password = "1234"
     var inM = false
-        get() = HAL.isBit(0b1000_0000)
+        get() = HAL.isBit(idx_M)
 
     fun init(){
         HAL.init()


### PR DESCRIPTION
## Summary
- keep `idx_M` as integer value 7
- `inM` still checks the configured mask

## Testing
- `kotlinc 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684849440ae0833285c45ab346a6523c