### PR TITLE
Fix ring buffer saturation logic

### DIFF
--- a/Hardware/KeyboardReader/RingBuffer/MAC/MAC.vhd
+++ b/Hardware/KeyboardReader/RingBuffer/MAC/MAC.vhd
@@ -56,6 +56,7 @@ end component;
 
 signal adder_out, mux_out, putReg_out, getReg_out: std_logic_vector (3 downto 0);
 signal equ : std_logic;
+signal count: unsigned(4 downto 0);
 
 begin
 
@@ -97,8 +98,21 @@ UEQ: Equality port map(
     O => equ
 );
 
-full <= equ and PUTGET;
-empty <= equ and (not PUTGET);
+process(clk, reset)
+begin
+    if reset = '1' then
+        count <= (others => '0');
+    elsif rising_edge(clk) then
+        if incPut = '1' and incGet = '0' and count /= "10000" then
+            count <= count + 1;
+        elsif incGet = '1' and incPut = '0' and count /= "00000" then
+            count <= count - 1;
+        end if;
+    end if;
+end process;
+
+full <= '1' when count = "10000" else '0';
+empty <= '1' when count = "00000" else '0';
 
 ADDR <= mux_out;
 end arc_MAC;


### PR DESCRIPTION
## Summary
- track ring buffer occupancy with a counter
- derive `full` and `empty` from the counter to avoid overwriting entries

## Testing
- `ghdl -a -fsynopsys Hardware/Utils/*.vhd Hardware/KeyboardReader/RingBuffer/MAC/*.vhd Hardware/KeyboardReader/RingBuffer/RAM.vhd Hardware/KeyboardReader/RingBuffer/RingBufferControl.vhd Hardware/KeyboardReader/RingBuffer/RingBuffer.vhd`
- `ghdl -a -fsynopsys Hardware/KeyboardReader/RingBuffer/Test-benches/*.vhd`
- `ghdl -e -fsynopsys RingBuffer_tb`
- `ghdl -r -fsynopsys RingBuffer_tb --stop-time=1us`

------
https://chatgpt.com/codex/tasks/task_e_6855369fd3548332afbc572a2c0dc142