### PR TITLE
Fix MAC counter overflow

### DIFF
--- a/Hardware/KeyboardReader/RingBuffer/MAC/MAC.vhd
+++ b/Hardware/KeyboardReader/RingBuffer/MAC/MAC.vhd
@@ -103,9 +103,9 @@ begin
     if reset = '1' then
         count <= (others => '0');
     elsif rising_edge(clk) then
-        if incPut = '1' and incGet = '0' and count /= "10000" then
+        if incPut = '1' and incGet = '0' and count < "10000" then
             count <= count + 1;
-        elsif incGet = '1' and incPut = '0' and count /= "00000" then
+        elsif incGet = '1' and incPut = '0' and count > "00000" then
             count <= count - 1;
         end if;
     end if;


### PR DESCRIPTION
## Summary
- prevent counter in MAC from exceeding valid 0..16 range

## Testing
- `ghdl -a -fsynopsys RingBuffer.vhd RingBufferControl.vhd RAM.vhd MAC/MAC.vhd MAC/MUX_4.vhd MAC/Equality.vhd ../../../Utils/Reg4.vhd ../../../Utils/ADDER4.vhd ../../../Utils/FULLADDER.vhd`
- `ghdl -a -fsynopsys RingBuffer_tb.vhd`
- `ghdl -e -fsynopsys RingBuffer_tb`
- `ghdl -r -fsynopsys RingBuffer_tb --stop-time=2500ns` *(fails: assertion in testbench)*

------
https://chatgpt.com/codex/tasks/task_e_685548faa50c83328606d8eec4036b51